### PR TITLE
fix: fix error Argument 2 (JS::NativeWebSocketModule::SpecConnectOpti…

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class ReconnectingWebSocket extends WebSocket{
             WebSocketModule.connect(
                 this.url,
                 this.protocols,
-                this.headers,
+                this.headers || {},
                 this._socketId,
             );
             this.onconnecting({reconnectAttempts:this.reconnectAttempts})


### PR DESCRIPTION
…ons) must not be null